### PR TITLE
Deno deploy

### DIFF
--- a/examples/custom-ssr/app.ts
+++ b/examples/custom-ssr/app.ts
@@ -4,7 +4,6 @@ import { renderToString } from "https://npm.reversehttp.com/preact,preact/hooks,
 import htmlTemplate from "../template.ts"
 import config from "../config.ts"
 
-// importing App component as using custom ssr handler
 import Home from "./src/Home.js"
 
 // Configure Peko

--- a/examples/eta-templating/app.ts
+++ b/examples/eta-templating/app.ts
@@ -34,6 +34,10 @@ files.forEach(file => {
 // SSR Route using eta renderFile fcn 
 Peko.addSSRRoute({
   route: "/",
+  module: {
+    srcURL: new URL(`./src/Home.js`, import.meta.url),
+    app: Home
+  },
   middleware: (_request) => ({ "server_time": `${Date.now()}` }),
   render: (_request, params) => renderToString(Home(params), null, null),
   template: (appHTML, _request, params) => renderFile("./template.eta", {

--- a/examples/eta-templating/app.ts
+++ b/examples/eta-templating/app.ts
@@ -1,11 +1,12 @@
 import * as Peko from "../../mod.ts"
+import config from "../config.ts"
+
 import { renderFile, configure as configureEta } from "https://deno.land/x/eta@v1.11.0/mod.ts"
 import { renderToString } from "https://npm.reversehttp.com/preact,preact/hooks,htm/preact,preact-render-to-string"
-
 import { lookup } from "https://deno.land/x/media_types/mod.ts"
 import { recursiveReaddir } from "https://deno.land/x/recursive_readdir/mod.ts"
 
-import config from "../config.ts"
+import Home from "./src/Home.js"
 
 // Configure Peko
 Peko.setConfig(config)
@@ -33,9 +34,8 @@ files.forEach(file => {
 // SSR Route using eta renderFile fcn 
 Peko.addSSRRoute({
   route: "/",
-  moduleURL: new URL("./src/Home.js", import.meta.url),
-  middleware: (_request) => ({ "server_time": Date.now() }),
-  render: (app, _request, params) => renderToString(app(params), null, null),
+  middleware: (_request) => ({ "server_time": `${Date.now()}` }),
+  render: (_request, params) => renderToString(Home(params), null, null),
   template: (appHTML, _request, params) => renderFile("./template.eta", {
       appHTML,
       title: `<title>Peko</title>`,

--- a/examples/eta-templating/src/Home.js
+++ b/examples/eta-templating/src/Home.js
@@ -2,7 +2,7 @@ import { html } from "https://npm.reversehttp.com/preact,preact/hooks,htm/preact
 
 import Layout from "./Layout.js"
 
-const Home = ({ server_time }) => {
+const Home = (props) => {
     return html`
         <${Layout} navColor="limegreen">
             <h1>Peko</h1>
@@ -11,7 +11,7 @@ const Home = ({ server_time }) => {
             </strong></p>
             <p>No bundling or build process. Server & Browser share all source modules!</p>
             
-            <p>Time of server request: <strong>${server_time}</strong></p>
+            <p>Time of server request: <strong>${props.server_time}</strong></p>
             <p>Time of latest render: <strong>${Date.now()}</strong> ${"<"}- changes with hydration!</p>
 
             <h2>Getting started</h2>

--- a/examples/preact/app.ts
+++ b/examples/preact/app.ts
@@ -1,12 +1,16 @@
 import * as Peko from "../../mod.ts"
 import { Route, SSRRoute } from "../../lib/types.ts"
+import config from "../config.ts"
 
 import { lookup } from "https://deno.land/x/media_types/mod.ts"
 import { recursiveReaddir } from "https://deno.land/x/recursive_readdir/mod.ts"
 import { renderToString } from "https://npm.reversehttp.com/preact,preact/hooks,htm/preact,preact-render-to-string"
 
+// import our app page components to pass into SSRRoute.render()
+import Home from "./src/pages/Home.js"
+import About from "./src/pages/About.js"
+
 import htmlTemplate from "../template.ts"
-import config from "../config.ts"
 
 // Configure Peko
 Peko.setConfig(config)
@@ -16,9 +20,8 @@ const ssrRoutes: SSRRoute[] = [
     // must be PekoPageRouteData type (see types.ts)
     {
         route: "/",
-        moduleURL: new URL("./src/pages/Home.js", import.meta.url),
-        middleware: (_request) => ({ "server_time": Date.now() }),
-        render: (app, _request, params) => renderToString(app(params), null, null),
+        middleware: (_request) => ({ "server_time": `${Date.now()}` }),
+        render: (_request, params) => renderToString(Home(params), null, null),
         template: (appHTML, _request, params) => htmlTemplate({
             appHTML,
             title: `<title>Peko</title>`,
@@ -33,8 +36,7 @@ const ssrRoutes: SSRRoute[] = [
     },
     {
         route: "/about",
-        moduleURL: new URL("./src/pages/About.js", import.meta.url),
-        render: (app) => renderToString(app(), null, null),
+        render: () => renderToString(About(), null, null),
         template: (appHTML, _request, _params) => htmlTemplate({
             appHTML,
             title: `<title>Peko | About</title>`,

--- a/examples/preact/app.ts
+++ b/examples/preact/app.ts
@@ -1,27 +1,34 @@
 import * as Peko from "../../mod.ts"
 import { Route, SSRRoute } from "../../lib/types.ts"
-import config from "../config.ts"
 
 import { lookup } from "https://deno.land/x/media_types/mod.ts"
 import { recursiveReaddir } from "https://deno.land/x/recursive_readdir/mod.ts"
 import { renderToString } from "https://npm.reversehttp.com/preact,preact/hooks,htm/preact,preact-render-to-string"
 
-// import our app page components to pass into SSRRoute.render()
+// Preact page component imports
+// These are necessary for Deno Deploy support
 import Home from "./src/pages/Home.js"
 import About from "./src/pages/About.js"
 
 import htmlTemplate from "../template.ts"
+import config from "../config.ts"
 
 // Configure Peko
 Peko.setConfig(config)
 
 // SSR'ed app page routes
 const ssrRoutes: SSRRoute[] = [
-    // must be PekoPageRouteData type (see types.ts)
+    // must be SSRRoute type (see types.ts)
     {
         route: "/",
+        // Note: only srcURL is required in most contexts except Deno Deploy
+        // which doesn't support dynamic imports
+        module: {
+            srcURL: new URL("./src/pages/Home.js", import.meta.url),
+            app: Home
+        },
         middleware: (_request) => ({ "server_time": `${Date.now()}` }),
-        render: (_request, params) => renderToString(Home(params), null, null),
+        render: (app, _request, params) => renderToString(app(params), null, null),
         template: (appHTML, _request, params) => htmlTemplate({
             appHTML,
             title: `<title>Peko</title>`,
@@ -36,7 +43,11 @@ const ssrRoutes: SSRRoute[] = [
     },
     {
         route: "/about",
-        render: () => renderToString(About(), null, null),
+        module: {
+            srcURL: new URL("./src/pages/About.js", import.meta.url),
+            app: About
+        },
+        render: (app) => renderToString(app(), null, null),
         template: (appHTML, _request, _params) => htmlTemplate({
             appHTML,
             title: `<title>Peko | About</title>`,
@@ -58,7 +69,7 @@ files.forEach(file => {
     const rootPath = `${Deno.cwd()}/examples/preact/src`
     const fileRoute = file.slice(rootPath.length)
 
-    // must be PekoStaticRoute type (see types.ts)
+    // must be StaticRoute type (see types.ts)
     Peko.addStaticRoute({
         route: fileRoute,
         fileURL: new URL(`./src/${fileRoute}`, import.meta.url),
@@ -68,7 +79,7 @@ files.forEach(file => {
 
 // Custom routes (e.g. any server-side API functions)
 const customRoutes: Route[] = [
-    // must be PekoRoute type (see types.ts)
+    // must be Route type (see types.ts)
     {
         route: "/api/parrotFcn",
         method: "POST",

--- a/examples/preact/src/pages/Home.js
+++ b/examples/preact/src/pages/Home.js
@@ -2,7 +2,7 @@ import { html } from "https://npm.reversehttp.com/preact,preact/hooks,htm/preact
 
 import Layout from "../layouts/Layout.js"
 
-const Home = ({ server_time }) => {
+const Home = (props) => {
     return html`
         <${Layout} navColor="limegreen">
             <h1>Peko</h1>
@@ -11,7 +11,7 @@ const Home = ({ server_time }) => {
             </strong></p>
             <p>No bundling or build process. Server & Browser share all source modules!</p>
             
-            <p>Time of server request: <strong>${server_time}</strong></p>
+            <p>Time of server request: <strong>${props.server_time}</strong></p>
             <p>Time of latest render: <strong>${Date.now()}</strong> ${"<"}- changes with hydration!</p>
 
             <h2>Getting started</h2>

--- a/examples/vue/app.ts
+++ b/examples/vue/app.ts
@@ -7,6 +7,9 @@ import { recursiveReaddir } from "https://deno.land/x/recursive_readdir/mod.ts"
 import htmlTemplate from "../template.ts"
 import config from "../config.ts"
 
+// Vue app module
+import App from "./src/app.js"
+
 // VUE FIX
 // Add document.createEvent and navigator.userAgent to global namespace
 declare global {
@@ -32,8 +35,7 @@ const pageRoutes: SSRRoute[] = [
     // must be PekoPageRouteData type (see types.ts)
     {
         route: "/",
-        moduleURL: new URL("./src/app.js", import.meta.url),
-        render: (app) => vueSSR.renderToString(app()),
+        render: () => vueSSR.renderToString(App()),
         template: (appHTML) => htmlTemplate({
             appHTML,
             title: `<title>Peko</title>`,

--- a/examples/vue/app.ts
+++ b/examples/vue/app.ts
@@ -35,6 +35,10 @@ const pageRoutes: SSRRoute[] = [
     // must be PekoPageRouteData type (see types.ts)
     {
         route: "/",
+        module: {
+            srcURL: new URL("./src/app.js", import.meta.url),
+            app: App
+        },
         render: () => vueSSR.renderToString(App()),
         template: (appHTML) => htmlTemplate({
             appHTML,

--- a/examples/vue/deno.json
+++ b/examples/vue/deno.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "dom.asynciterable",
+      "deno.ns",
+      "deno.unstable"
+    ]
+  }
+}

--- a/lib/handlers/ssr.ts
+++ b/lib/handlers/ssr.ts
@@ -9,16 +9,9 @@ import { HandlerParams, SSRRoute } from "../types.ts"
  * @returns Promise<Response>
  */
 export const ssrHandler = async (ssrData: SSRRoute, request: Request, params: HandlerParams) => {
-
-    // import the app module
-    const appImport = await import(ssrData.moduleURL.pathname)
-        
-    // app module must export app as default
-    const app = appImport.default
-
     // use provided render and template fcns for HTML generation
-    const HTMLResult = await ssrData.render(app, request, params)    
-    const HTML = await ssrData.template(HTMLResult, request, params)
+    const AppHTML = await ssrData.render(request, params) 
+    const HTML = await ssrData.template(AppHTML, request, params)
 
     return new Response(HTML, {
         headers : new Headers({

--- a/lib/handlers/ssr.ts
+++ b/lib/handlers/ssr.ts
@@ -9,9 +9,26 @@ import { HandlerParams, SSRRoute } from "../types.ts"
  * @returns Promise<Response>
  */
 export const ssrHandler = async (ssrData: SSRRoute, request: Request, params: HandlerParams) => {
+    let app: Function
+
+    // prioritise module.app over dynamic import for Deno Deploy support
+    if (ssrData.module.app) {
+        app = ssrData.module.app
+    } else if (ssrData.module.srcURL) {
+        // import the app module
+        const appImport = await import(ssrData.module.srcURL.pathname)
+            
+        // app module must export app as default
+        app = appImport.default
+    } else {
+        throw new Error("Must provide module.app or module.srcURL to ssrHandler.")
+    }
+
     // use provided render and template fcns for HTML generation
-    const AppHTML = await ssrData.render(request, params) 
-    const HTML = await ssrData.template(AppHTML, request, params)
+    const HTMLResult = await ssrData.render(app, request, params)    
+    const HTML = await ssrData.template(HTMLResult, request, params)
+
+    // TODO: devMode src listeners WASM module graphing 
 
     return new Response(HTML, {
         headers : new Headers({

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -12,7 +12,7 @@ export type Config = {
     errorHandler: ErrorHandler
 }
 
-export type HandlerParams = Record<string, any>
+export type HandlerParams = Record<string, string>
 export type Middleware = (request: Request) => HandlerParams
 export type Handler = (request: Request, params: HandlerParams) => Response | Promise<Response>
 
@@ -31,12 +31,11 @@ export type StaticRoute = {
 }
 
 export type HTMLContent = `<${string}>`
-export type Template = (ssrResult: HTMLContent, request?: Request, params?: HandlerParams) => string
-export type Render = (app: Function, request?: Request, params?: HandlerParams) => HTMLContent | Promise<HTMLContent>
+export type Template = (ssrResult: HTMLContent, request: Request, params: HandlerParams) => string
+export type Render = (request: Request, params: HandlerParams) => HTMLContent | Promise<HTMLContent>
 
 export type SSRRoute = { 
     route: string
-    moduleURL: URL
     middleware?: Middleware
     template: Template
     render: Render

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -32,10 +32,14 @@ export type StaticRoute = {
 
 export type HTMLContent = `<${string}>`
 export type Template = (ssrResult: HTMLContent, request: Request, params: HandlerParams) => string
-export type Render = (request: Request, params: HandlerParams) => HTMLContent | Promise<HTMLContent>
+export type Render = (app: Function, request: Request, params: HandlerParams) => HTMLContent | Promise<HTMLContent>
 
 export type SSRRoute = { 
     route: string
+    module: {
+        srcURL?: URL
+        app?: Function
+    }
     middleware?: Middleware
     template: Template
     render: Render


### PR DESCRIPTION
Changes to ssrHandler mean dynamic imports are no longer mandatory and will be skipped if module.app is provided in ssrData. 