### PR TITLE
Browser cache utilization

### DIFF
--- a/examples/preact/app.ts
+++ b/examples/preact/app.ts
@@ -1,8 +1,8 @@
 import * as Peko from "../../mod.ts"
 import { Route, SSRRoute } from "../../lib/types.ts"
 
-import { lookup } from "https://deno.land/x/media_types/mod.ts"
-import { recursiveReaddir } from "https://deno.land/x/recursive_readdir/mod.ts"
+import { lookup } from "https://deno.land/x/media_types@v3.0.3/mod.ts"
+import { recursiveReaddir } from "https://deno.land/x/recursive_readdir@v2.0.0/mod.ts"
 import { renderToString } from "https://npm.reversehttp.com/preact,preact/hooks,htm/preact,preact-render-to-string"
 
 // Preact page component imports

--- a/lib/handlers/static.ts
+++ b/lib/handlers/static.ts
@@ -1,26 +1,32 @@
 import { StaticRoute } from "../types.ts"
+import { hasher } from "../utils/hasher.ts"
 
-// I think there is a much more efficient method by streaming the file...
+// I think there is a much more efficient method by streaming the file into the response body?
 
 /**
  * Static asset request handler
  * 
- * @param request: Request
- * @param params: HandlerParams
  * @param staticData: StaticRoute
  * @returns Promise<Response>
  */
 export const staticHandler = async (staticData: StaticRoute) => {
-    let filePath = decodeURI(staticData.fileURL.pathname)
-    
-    // fix annoying windows paths
-    if (Deno.build.os === "windows") filePath = filePath.substring(1)
+  let filePath = decodeURI(staticData.fileURL.pathname)
+  
+  // fix annoying windows paths
+  if (Deno.build.os === "windows") filePath = filePath.substring(1)
 
-    const body = await Deno.readFile(filePath)
+  const body = await Deno.readFile(filePath)
+  const hashString = hasher(body.toString())
 
-    return new Response(body, {
-        headers: new Headers(staticData.contentType ? {
-          'Content-Type': staticData.contentType
-        } : {})
+  return new Response(body, {
+    headers: new Headers({
+      'Content-Type': staticData.contentType ? staticData.contentType : 'text/plain',
+      'Cache-Control': 'public, max-age=31536000',
+      // create hash for ETag
+      // this lets browser check if file has changed by returning ETag in "if-none-match" header.
+      // devMode: new ETag in each response so no browser caching
+      // not devMode + memoized: ETag matches "if-none-match" header so 304 (not modified) response given
+      'ETag': hashString
     })
+  })
 }

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -1,0 +1,91 @@
+import { Route, SSRRoute, StaticRoute } from "./types.ts"
+import { getConfig } from "./config.ts"
+import { createResponseCache } from "./utils/cacher.ts"
+import { staticHandler } from "./handlers/static.ts"
+import { ssrHandler } from "./handlers/ssr.ts"
+import { routes } from "./server.ts"
+
+/**
+ * Add a basic route to your peko web server.
+ * 
+ * See "lib/types.ts" for Middleware, Handler & HandlerParams type details
+ * 
+ * Note: "handlerParams" argument of Middleware and Handler used to pass data from middleware logic to handler logic.
+ * 
+ * @param routeData { 
+        route: string - e.g. "/"
+        method: string - e.g. "GET"
+        middleware?: Middleware (optional) - e.g. (_request, handlerParams) => handlerParams["time_of_request"] = Date.now()
+        handler: Handler - e.g. (_request, handlerParams) => new Response(`${handlerParams["time_of_request"]}`)
+    }
+ */
+export const addRoute = (routeData: Route) => routes.push(routeData)
+
+/**
+ * Add a static route
+ * 
+ * Uses staticHandler from /lib/handlers/static.ts
+ * 
+ * @param staticRouteData { 
+        route: string - e.g. "favicon.png"
+        middleware?: Middleware (optional)
+        fileURL: URL - e.g. new URL("./assets/favicon.png")
+        contentType: string - e.g. "image/png"
+    }
+  */
+export const addStaticRoute = (staticRouteData: StaticRoute) => {
+  const config = getConfig()
+
+  const memoizeHandler = createResponseCache({
+    lifetime: Infinity
+  }) 
+
+  const cachedStaticHandler = memoizeHandler(() => staticHandler(staticRouteData))
+
+  return addRoute({
+      route: staticRouteData.route,
+      method: "GET",
+      middleware: staticRouteData.middleware,
+      handler: async (request, _params) => !config.devMode
+        ? await cachedStaticHandler(request)
+        : await staticHandler(staticRouteData)
+  })
+}
+
+/**
+ * Add a Server-Side Rendering route
+ * 
+ * Uses ssrHandler from /lib/handlers/ssr.ts
+ * 
+ * See "lib/types.ts" for Template, Render & CustomTags type details
+ * 
+ * @param ssrRouteData { 
+        route: string - e.g. "/home"
+        middleware?: Middleware (optional)
+        template: Template - e.g. (ssrResult, customTags, request) => `<!DOCTYPE html><html><head>${customTags.title}</head><body>${ssrResult}</body></html>`
+        render: Render - e.g. (app) => renderToString(app())
+        moduleURL: URL - e.g. new URL("./src/home.js")
+        customTags?: CustomTags - e.g. () => ({ title: <title>Home Page!</title> })
+        cacheLifetime?: number - e.g. 3600000
+    }
+  */
+export const addSSRRoute = (ssrRouteData: SSRRoute) => {
+    const config = getConfig()
+
+    const memoizeHandler = createResponseCache({
+        lifetime: ssrRouteData.cacheLifetime
+    }) 
+
+    const cachedSSRHandler = memoizeHandler((request, params) => ssrHandler(ssrRouteData, request, params))
+
+    return addRoute({
+        route: ssrRouteData.route,
+        method: "GET",
+        middleware: ssrRouteData.middleware,
+        handler: async (request, params) => !config.devMode
+            // use cache-enabled fcn if not in prod env and pass in params 
+            // so we cache renders by params as well as SSRRoute data
+            ? await cachedSSRHandler(request, params)
+            : await ssrHandler(ssrRouteData, request, params)
+    })
+}

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -36,9 +36,7 @@ export const addRoute = (routeData: Route) => routes.push(routeData)
 export const addStaticRoute = (staticRouteData: StaticRoute) => {
   const config = getConfig()
 
-  const memoizeHandler = createResponseCache({
-    lifetime: Infinity
-  }) 
+  const memoizeHandler = createResponseCache() 
 
   const cachedStaticHandler = memoizeHandler(() => staticHandler(staticRouteData))
 

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -1,15 +1,9 @@
 import { serve } from "https://deno.land/std@0.139.0/http/server.ts"
+import { Route } from "./types.ts"
 import { getConfig } from "./config.ts"
-
-import { staticHandler } from "./handlers/static.ts"
-import { ssrHandler } from "./handlers/ssr.ts"
-
 import { logRequest } from "./utils/logger.ts"
-import { createResponseCache } from "./utils/cacher.ts"
 
-import { Route, SSRRoute, StaticRoute } from "./types.ts"
-
-const routes: Route[] = []
+export const routes: Route[] = []
 
 /**
  * Begin listening to http requests and serve matching routes.
@@ -24,22 +18,26 @@ export const start = () => {
     config.logString(`Starting Peko server on port ${config.port} in ${config.devMode ? "development" : "production"} mode with routes:`)
     routes.forEach(route => config.logString(JSON.stringify(route)))
 
-    let lexRequest: Request;
-    const requestHandler = async (request: Request) => {
-        const start = Date.now()
-        const requestURL = new URL(request.url)
-        const route = routes.find(route => route.route === requestURL.pathname && route.method === request.method)
+    // does having respond in lex scope fix this?
+    let lexRequest: Request
+    let lexStart: number
 
+    // general-purpose function used in various positions in the file
+    const respond = (status: number, response: Promise<Response> | Response) => {
+        const responseTime = Date.now() - lexStart
+        logRequest(lexRequest, status, lexStart, responseTime)
+        return response
+    }
+
+    const requestHandler = async (request: Request) => {
         // store request arg in start() block-scope 
         // to avoid strange closure bug that doesn't seem to affect "start"...
         // this bug began when logRequest() was moved to lib/utils/logger.ts
         lexRequest = request
-        
-        const respond = (status: number, response: Promise<Response> | Response) => {
-            const responseTime = Date.now() - start
-            logRequest(lexRequest, status, start, responseTime)
-            return response
-        }
+        lexStart = Date.now()
+
+        const requestURL = new URL(request.url)
+        const route = routes.find(route => route.route === requestURL.pathname && route.method === request.method)
 
         if (!route) return respond(404, await config.errorHandler(404, request))
         
@@ -69,80 +67,5 @@ export const start = () => {
     serve(requestHandler, { 
         hostname: config.hostname, 
         port: config.port 
-    })
-}
-
-/**
- * Add a basic route to your peko web server.
- * 
- * See "lib/types.ts" for Middleware, Handler & HandlerParams type details
- * 
- * Note: "handlerParams" argument of Middleware and Handler used to pass data from middleware logic to handler logic.
- * 
- * @param routeData { 
-        route: string - e.g. "/"
-        method: string - e.g. "GET"
-        middleware?: Middleware (optional) - e.g. (_request, handlerParams) => handlerParams["time_of_request"] = Date.now()
-        handler: Handler - e.g. (_request, handlerParams) => new Response(`${handlerParams["time_of_request"]}`)
-    }
- */
-export const addRoute = (routeData: Route) => routes.push(routeData)
-
-/**
- * Add a static route
- * 
- * Uses staticHandler from /lib/handlers/static.ts
- * 
- * @param staticRouteData { 
-        route: string - e.g. "favicon.png"
-        middleware?: Middleware (optional)
-        fileURL: URL - e.g. new URL("./assets/favicon.png")
-        contentType: string - e.g. "image/png"
-    }
- */
-export const addStaticRoute = (staticRouteData: StaticRoute) => {
-    return addRoute({
-        route: staticRouteData.route,
-        method: "GET",
-        middleware: staticRouteData.middleware,
-        handler: (_req, _params) => staticHandler(staticRouteData)
-    })
-}
-
-/**
- * Add a Server-Side Rendering route
- * 
- * Uses ssrHandler from /lib/handlers/ssr.ts
- * 
- * See "lib/types.ts" for Template, Render & CustomTags type details
- * 
- * @param ssrRouteData { 
-        route: string - e.g. "/home"
-        middleware?: Middleware (optional)
-        template: Template - e.g. (ssrResult, customTags, request) => `<!DOCTYPE html><html><head>${customTags.title}</head><body>${ssrResult}</body></html>`
-        render: Render - e.g. (app) => renderToString(app())
-        moduleURL: URL - e.g. new URL("./src/home.js")
-        customTags?: CustomTags - e.g. () => ({ title: <title>Home Page!</title> })
-        cacheLifetime?: number - e.g. 3600000
-    }
- */
-export const addSSRRoute = (ssrRouteData: SSRRoute) => {
-    const config = getConfig()
-
-    const memoizeHandler = createResponseCache({
-        lifetime: ssrRouteData.cacheLifetime
-    }) 
-
-    const cachedSSRHandler = memoizeHandler((request, params) => ssrHandler(ssrRouteData, request, params))
-
-    return addRoute({
-        route: ssrRouteData.route,
-        method: "GET",
-        middleware: ssrRouteData.middleware,
-        handler: async (request, params) => !config.devMode
-            // use cache-enabled fcn if not in prod env and pass in params 
-            // so we cache renders by params as well as SSRRoute data
-            ? await cachedSSRHandler(request, params)
-            : await ssrHandler(ssrRouteData, request, params)
     })
 }

--- a/lib/utils/cacher.ts
+++ b/lib/utils/cacher.ts
@@ -1,4 +1,3 @@
-import { getConfig } from "../config.ts"
 import { Handler, HandlerParams } from "../types.ts"
 
 export type CacheItem = { key: string, value: Response, dob: number }
@@ -18,12 +17,10 @@ export const createResponseCache = (options?: Partial<CacheOptions>) => {
   // class would be more general-purpose as can access private vars etc
   // but closure is more sleek and inline with project conventions
 
-  const config = getConfig()
-
   let cache: Array<CacheItem> = []
   const lifetime = options && options.lifetime 
     ? options.lifetime 
-    : config.defaultCacheLifetime
+    : Infinity
 
   const getLatestCacheItem = (key: string) => {
     // return first valid item if found
@@ -48,20 +45,25 @@ export const createResponseCache = (options?: Partial<CacheOptions>) => {
 
       const latest = getLatestCacheItem(key)
       if (latest) {
-        // return clone of response - one-use original lives in cache
+        // if resource ETag present in "if-none-match" request headers
+        // check matches cached resource and respond with 304 if so
+        const ifNoneMatch = request.headers.get("if-none-match")
+        const ETag = latest.value.headers.get("ETag")
+        if (ETag && ifNoneMatch?.includes(ETag)) {
+          return new Response(null, {
+            headers: latest.value.headers,
+            status: 304
+          })
+        }
+
+        // else respond 200 clone of response - one-use original lives in cache
         return latest.value.clone()
       }
 
       // calc new value then update cache asynchronously to not block process before return
       const response = await fcn(request, params)
+      updateCache(key, response)
 
-      // set status on cached responses to 304 to utilise browser caching
-      // how to serve 304s only after a client has already requested? 
-      // do we detect code changes and automate this?
-      // will images etc be autocached
-      updateCache(key, new Response(response.body, { status: 304, headers: response.headers }))
-
-      // return clone of response - one-use original lives in cache
       return response.clone()
     }
   }

--- a/lib/utils/hasher.ts
+++ b/lib/utils/hasher.ts
@@ -1,0 +1,9 @@
+import { createHash } from "https://deno.land/std@0.140.0/hash/mod.ts";
+
+export const hasher = (contents: string) => {
+  const hash = createHash("md5")
+  hash.update(contents)
+  const hashString = hash.toString()
+
+  return hashString
+}

--- a/mod.ts
+++ b/mod.ts
@@ -2,10 +2,13 @@
  * The Featherweight Deno Library for Modern JS Apps.
  */
 
-export { start, addRoute, addStaticRoute, addSSRRoute } from "./lib/server.ts"
+// Core functions
+export { start } from "./lib/server.ts"
+export { addRoute, addStaticRoute, addSSRRoute } from "./lib/routes.ts"
 export { getConfig, setConfig } from "./lib/config.ts"
+
+// Internals for custom handlers etc...
 export { staticHandler } from "./lib/handlers/static.ts"
 export { ssrHandler } from "./lib/handlers/ssr.ts"
-
 export { logRequest } from "./lib/utils/logger.ts"
 export { createResponseCache } from "./lib/utils/cacher.ts"


### PR DESCRIPTION
cacher now responds with an empty 304 if request ifNoneMatch header matches ETag of cached response

Note: Cacher does need some testing and thought. The cacher assumes the user's frontend app is predictable (i.e. same input params will result in the same HTML output). If constant params result in different HTML (e.g. using Date.now() inside app code) cacher will still return cached value as it uses params to distinguish between renders. Must clearly communicate this to developers.